### PR TITLE
proposed fix for PLXCOMP-207

### DIFF
--- a/src/main/java/org/codehaus/plexus/components/io/attributes/AttributeParser.java
+++ b/src/main/java/org/codehaus/plexus/components/io/attributes/AttributeParser.java
@@ -34,7 +34,7 @@ abstract class AttributeParser
     implements StreamConsumer
 {
     protected static final Pattern LINE_SPLITTER = Pattern.compile( "\\s+" );
-    protected static final int[] LS_LAST_DATE_PART_INDICES = { 7, 7, 6 };
+    protected static final int[] LS_LAST_DATE_PART_INDICES = { 7, 7, 6, 7, 7 };
 
     protected final StreamConsumer delegate;
 
@@ -56,7 +56,11 @@ abstract class AttributeParser
         this.logger = logger;
         LS_DATE_FORMATS =
             new SimpleDateFormat[]{ new SimpleDateFormat( "MMM dd yyyy" ), new SimpleDateFormat( "MMM dd HH:mm" ),
-                new SimpleDateFormat( "yyyy-MM-dd HH:mm" ), };
+                new SimpleDateFormat( "yyyy-MM-dd HH:mm" ),
+                // month-day order is reversed for most non-US locales on MacOSX and FreeBSD
+                new SimpleDateFormat( "dd MMM HH:mm" ),
+                new SimpleDateFormat( "dd MMM yyyy" )
+            };
     }
 
     public void consumeLine( String line )


### PR DESCRIPTION
On MacOSX and FreeBSD, the date format of the 
'ls -l' output can have reversed month-day order 
for most non-US locales ($LANG) [1,2].
Add two more SimpleDateFormats (for
<= 6 months and > 6 months ls date formats)
with order day-month.

[1]
http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man1/ls.1.html
[2] http://www.freebsd.org/cgi/man.cgi?query=ls
