### PR TITLE
[PLXCOMP-241] Don't assume sub-second timestamp granularity in ResourcesTest

### DIFF
--- a/src/test/java/org/codehaus/plexus/components/io/filemappers/ResourcesTest.java
+++ b/src/test/java/org/codehaus/plexus/components/io/filemappers/ResourcesTest.java
@@ -139,7 +139,7 @@ public class ResourcesTest extends PlexusTestCase
         assertTrue( res.getLastModified() != PlexusIoResource.UNKNOWN_MODIFICATION_DATE );
         if ( res instanceof PlexusIoFileResource )
         {
-            assertEquals( res.getLastModified(), file.lastModified() );
+            assertEquals( res.getLastModified() / 1000, file.lastModified() / 1000 );
         }
         assertTrue( res.getSize() != PlexusIoResource.UNKNOWN_RESOURCE_SIZE );
         assertEquals( res.getSize(), file.length() );


### PR DESCRIPTION
Some operating systems or file systems may support file time stamps
with one second granularity. On such systems ResourcesTest.compare
would fail.
