### PR TITLE
[PLXCOMP-244] Don't try to set attributes of symbolic links

### DIFF
--- a/src/main/java/org/codehaus/plexus/components/io/attributes/Java7AttributeUtils.java
+++ b/src/main/java/org/codehaus/plexus/components/io/attributes/Java7AttributeUtils.java
@@ -52,11 +52,8 @@ public class Java7AttributeUtils
         throws IOException
     {
         final Path path = file.toPath();
-        if (Files.isSymbolicLink( path )){
-            if (Files.readSymbolicLink( path ).toFile().exists()){
-                Files.setPosixFilePermissions( path, getPermissions( mode ) );
-            }
-        } else {
+        if ( !Files.isSymbolicLink( path ) )
+        {
             Files.setPosixFilePermissions( path, getPermissions( mode ) );
         }
     }


### PR DESCRIPTION
Symbolic links themselves don't have changeable file attributes. Trying to change attributes of target file is IMHO a bad idea.

Example 1: Symlink in archive is stored with attributes 777. Extracting such symlink with plexus-archiver will make target file world-writable!

Example 2: Symlink points to system file (owned by root). If ordinary user tries to extract such symlink with plexus-archiver then there will be `java.nio.file.FileSystemException: Operation not permitted` thrown as ordinary user cannot change attributes of file owned by root.

JIRA bug report: http://jira.codehaus.org/browse/PLXCOMP-244
